### PR TITLE
Alterações de Domain

### DIFF
--- a/src/Swarm.Domain/Entities/Patterns/SingleShotPattern.cs
+++ b/src/Swarm.Domain/Entities/Patterns/SingleShotPattern.cs
@@ -11,12 +11,12 @@ public sealed class SingleShotPattern(
     float lifetime = 1.5f
 ) : IFirePattern
 {
-    public IEnumerable<Projectile> Fire(Vector2 origin)
+    public IEnumerable<Projectile> Fire(Vector2 origin, Direction facing)
     {
         yield return new Projectile(
             EntityId.New(),
             origin,
-            Direction.From(1f, 0f),
+            facing,
             projectileSpeed,
             projectileRadius,
             damage,

--- a/src/Swarm.Domain/Entities/Player.cs
+++ b/src/Swarm.Domain/Entities/Player.cs
@@ -33,7 +33,7 @@ public sealed class Player(
     }
 
     public bool TryFire(out IEnumerable<Projectile> projectiles) =>
-        ActiveWeapon.TryFire(Position, out projectiles);
+        ActiveWeapon.TryFire(Position, Rotation, out projectiles);
 
     public void Tick(DeltaTime dt, Bounds stage)
     {

--- a/src/Swarm.Domain/Entities/Weapon.cs
+++ b/src/Swarm.Domain/Entities/Weapon.cs
@@ -11,7 +11,7 @@ public sealed class Weapon(
 {
     public IFirePattern Pattern { get; } = pattern;
     public Cooldown Cooldown { get; private set; } = cooldown;
-    public bool TryFire(Vector2 origin, out IEnumerable<Projectile> projectiles)
+    public bool TryFire(Vector2 origin, Direction facing, out IEnumerable<Projectile> projectiles)
     {
         Cooldown = Cooldown.ConsumeIfReady(out var fired);
         if (!fired)
@@ -20,7 +20,7 @@ public sealed class Weapon(
             return false;
         }
 
-        projectiles = Pattern.Fire(origin);
+        projectiles = Pattern.Fire(origin, facing);
         return true;
     }
 

--- a/src/Swarm.Domain/Interfaces/IFirePattern.cs
+++ b/src/Swarm.Domain/Interfaces/IFirePattern.cs
@@ -5,5 +5,5 @@ namespace Swarm.Domain.Interfaces;
 
 public interface IFirePattern
 {
-    IEnumerable<Projectile> Fire(Vector2 origin);
+    IEnumerable<Projectile> Fire(Vector2 origin, Direction facing);
 }


### PR DESCRIPTION
- Player entity tem uma propriedade Rotation
- Criamos um método RotateTowards para garantir que o Player sempre esteja olhando para um Vector2 target
- Adicionamos o método IsZero para o primitivo Vector2, efetuando uma verificacão matemática.
- Projéteis devem seguir a orientação do Player, logo inserimos  um param `facing` no TryFire do IFirePattern. Fizemos a implementação concreta no SingleShotPattern, Weapon e Player.