### PR TITLE
Task/presentation

### DIFF
--- a/src/Swarm.Presentation/Input/InputManager.cs
+++ b/src/Swarm.Presentation/Input/InputManager.cs
@@ -20,12 +20,14 @@ public sealed class InputManager
         bool fire = (kb.IsKeyDown(Keys.Space) && !_prevKb.IsKeyDown(Keys.Space))
                  || (mouse.LeftButton == ButtonState.Pressed && _prevMouse.LeftButton == ButtonState.Released);
 
+        bool reload = kb.IsKeyDown(Keys.E) && ! _prevKb.IsKeyDown(Keys.E);
+
         bool pause = kb.IsKeyDown(Keys.P) && !_prevKb.IsKeyDown(Keys.P);
 
         bool save = kb.IsKeyDown(Keys.F5) && !_prevKb.IsKeyDown(Keys.F5);
         bool load = kb.IsKeyDown(Keys.F9) && !_prevKb.IsKeyDown(Keys.F9);
 
-        var state = new InputState(dx, dy, mouse.X, mouse.Y, fire, pause, save, load);
+        var state = new InputState(dx, dy, mouse.X, mouse.Y, fire, reload, pause, save, load);
 
         _prevKb = kb;
         _prevMouse = mouse;

--- a/src/Swarm.Presentation/Input/InputState.cs
+++ b/src/Swarm.Presentation/Input/InputState.cs
@@ -6,6 +6,7 @@ public readonly record struct InputState(
     float MouseX,
     float MouseY,
     bool Fire,
+    bool Reload,
     bool Pause,
     bool Save,
     bool Load

--- a/src/Swarm.Presentation/Renderers/HudRenderer.cs
+++ b/src/Swarm.Presentation/Renderers/HudRenderer.cs
@@ -19,13 +19,14 @@ public class HudRenderer(
 
     public void Draw(HudDTO hud)
     {
-        var scoreText = $"Score: {hud.Score}";
+        var scoreText = $"Enemies killed: {hud.Score}";
         var hpText = $"HP: {hud.HP}";
         var enemiesText = $"Enemies alive: {hud.NumberOfEnemiesAlive}";
+        var weaponString = hud.WeaponString;
 
         var timerText = $"Timer: {hud.Timer}";
         
-        var leftText = $"{hpText} {scoreText} {enemiesText} {timerText}";
+        var leftText = $"{hpText} {weaponString} {scoreText} {enemiesText} {timerText}";
         var leftPos = new Vector2(10, 10);
 
         var levelText = $"{hud.GameLevel}";

--- a/src/Swarm.Presentation/Swarm.cs
+++ b/src/Swarm.Presentation/Swarm.cs
@@ -49,14 +49,16 @@ public class Swarm : Game
             ),
             LevelConfig: new LevelConfig(
                 Weapon: new WeaponConfig(
+                    Name: "oitão",
                     Damage: 1,
-                    ProjectileSpeed: 420f,
+                    ProjectileSpeed: 840f,
                     ProjectileRadius: 4f,
                     RatePerSecond: 6f,
-                    ProjectileLifetimeSeconds: 2.0f
+                    ProjectileLifetimeSeconds: 1.2f,
+                    MaxAmmo: 6
                 ),
-                PlayerAreaConfig: new AreaConfig(X: 50, Y: 50, Radius: 20),
-                TargetAreaConfig: new AreaConfig(X: 900, Y: 500, Radius: 20),
+                PlayerAreaConfig: new AreaConfig(X: 50, Y: 50, Radius: 40),
+                TargetAreaConfig: new AreaConfig(X: 900, Y: 500, Radius: 40),
                 Walls:
                 [
                     new(X: 200, Y: 100, Radius: 30),
@@ -64,12 +66,12 @@ public class Swarm : Game
                 ],
                 Spawners:
                 [
-                    // new(
-                    //     X: 400,
-                    //     Y: 300, CooldownSeconds: 0.8f,
-                    //     BehaviourType: "",
-                    //     SpawnObjectType: "BasicEnemy"
-                    // ),
+                    new(
+                        X: 400,
+                        Y: 300, CooldownSeconds: 0.8f,
+                        BehaviourType: "",
+                        SpawnObjectType: "BasicEnemy"
+                    ),
 
                     new(
                         X: 600,
@@ -136,6 +138,8 @@ public class Swarm : Game
         _service.ApplyInput(state.DirX, state.DirY, (state.DirX == 0f && state.DirY == 0f) ? 0f : _moveSpeed);
 
         if (state.Fire) _service.Fire();
+
+        if (state.Reload) _service.Reload();
 
         _service.RotateTowards(state.MouseX, state.MouseY);
 


### PR DESCRIPTION
* 32b54af (HEAD -> task/Presentation, origin/task/Presentation) :trophy::video_game::gun: Presentation implementa um tipo básico de arma
* 9dd7721 :computer: HudRenderer renderiza a string de info sobre a arma
* bfd6db3 :joystick: Input para a tecla E como reload
*   4f66c68 (origin/feature/Player-Weapon, feature/Player-Weapon) Merge pull request #39 from wierdest/task/Application
|\  
| * a0c4de3 (origin/task/Application) :video_game::gun: GameSessionService monta PlayerWeapon e implementa reload
| * 042501f :earth_africa: DomainMapper mapeia string de info sobre arma
| * 848a8a6 :computer: HudDTO passa info sobre armas e reload
| * 5a1b7f4 :gun: Reload no contrato da service
| * e6e548b :gun: WeaponConfig atende a PlayerWeapon
|/  
*   9ebcc4b Merge pull request #38 from wierdest/task/Domain
|\  
| | *   b5ce2ea (origin/feature/Player-Rotation) Merge pull request #37 from wierdest/revert-36-task/Domain
| | |\  
| | | * 6c17d4f (origin/revert-36-task/Domain) Revert "Task/domain"
| | |/  
| | *   f103fb7 Merge pull request #36 from wierdest/task/Domain
| |/|   
| * | 9ada0e4 (origin/task/Domain) :gun::video_game::joystick Reload
| * | a03d28b :joystick::gun: Estendendo weapon para Player com controle de ammo e reload
|/ /  
* |   862a3f7 (origin/main, main) Merge pull request #35 from wierdest/feature/BossEnemy
