### PR TITLE
Feature/player weapon

### DIFF
--- a/src/Swarm.Application/Config/WeaponConfig.cs
+++ b/src/Swarm.Application/Config/WeaponConfig.cs
@@ -1,7 +1,9 @@
 ﻿namespace Swarm.Application.Config;
 
 public sealed record class WeaponConfig(
+    string Name,
     int Damage,
+    int MaxAmmo,
     float ProjectileSpeed,
     float ProjectileRadius,
     float RatePerSecond,

--- a/src/Swarm.Application/Contracts/IGameSessionService.cs
+++ b/src/Swarm.Application/Contracts/IGameSessionService.cs
@@ -9,6 +9,7 @@ public interface IGameSessionService
     void ApplyInput(float dirX, float dirY, float speed);
     void Stop();
     void Fire();
+    void Reload();
     void RotateTowards(float targetX, float targetY);
     void Pause();
     void Resume();

--- a/src/Swarm.Application/DTOs/HudDTO.cs
+++ b/src/Swarm.Application/DTOs/HudDTO.cs
@@ -1,3 +1,11 @@
 ﻿namespace Swarm.Application.DTOs;
 
-public record class HudDTO(int Score, int HP, string Timer, int NumberOfEnemiesAlive, string GameLevel);
+public record class HudDTO(
+    int Score,
+    int HP,
+    string Timer,
+    int NumberOfEnemiesAlive,
+    string GameLevel,
+    string WeaponString
+    
+    );

--- a/src/Swarm.Application/Services/DomainMappers.cs
+++ b/src/Swarm.Application/Services/DomainMappers.cs
@@ -35,7 +35,36 @@ static class DomainMappers
 
         levelStateString = s.IsTimeUp ? "TIME IS UP!!!" : levelStateString;
 
-        var hud = new HudDTO(s.Score.Value, p.HP.Value, s.TimeString, enemies.Count, levelStateString);
+        var weaponString = "";
+        if (p.ActiveWeapon is not null)
+        {
+            var w = p.ActiveWeapon;
+
+            if (w.CurrentAmmo == 0)
+            {
+                if (p.Ammo == 0)
+                {
+                    weaponString = $"{w.Name} [Find some ammo!]";
+                }
+                else
+                {
+                    weaponString = $"{w.Name} [Press E to reload] | Bullets: {p.Ammo}";
+                }
+            }
+            else
+            {
+                weaponString = $"{w.Name} {w.CurrentAmmo}/{w.MaxAmmo} | Bulllets: {p.Ammo}";
+            }
+        }
+
+        var hud = new HudDTO(
+            s.Score.Value,
+            p.HP,
+            s.TimeString,
+            enemies.Count,
+            levelStateString,
+            weaponString
+            );
 
         var walls = new List<DrawableDTO>(s.Walls.Count);
         foreach (var w in s.Walls)

--- a/src/Swarm.Application/Services/GameSessionService.cs
+++ b/src/Swarm.Application/Services/GameSessionService.cs
@@ -47,6 +47,8 @@ public sealed class GameSessionService(
 
     public void Fire() => _session?.Fire();
 
+    public void Reload() => _session?.Reload();
+    
     public GameSnapshot GetSnapshot()
     {
         if (_session is null || _playerArea is null || _targetArea is null)
@@ -89,9 +91,22 @@ public sealed class GameSessionService(
 
         var cooldown = new Cooldown(1f / weaponConfig.RatePerSecond);
 
-        var playerWeapon = new Weapon(pattern, cooldown, ProjectileOwnerTypes.Player);
+        var playerWeapon = new PlayerWeapon(
+            weaponConfig.Name,
+            pattern,
+            cooldown,
+            ProjectileOwnerTypes.Player,
+            weaponConfig.MaxAmmo
+        );
 
-        var player = new Player(EntityId.New(), playerStart, playerRadius, playerWeapon);
+        var player = new Player(
+            EntityId.New(),
+            playerStart,
+            playerRadius,
+            playerWeapon,
+            weaponConfig.MaxAmmo * 4
+            
+            );
 
         var wallsDefs = level.Walls
             .Select(a => (new Vector2(a.X, a.Y), new Radius(a.Radius)));

--- a/src/Swarm.Domain/Entities/GameSession.cs
+++ b/src/Swarm.Domain/Entities/GameSession.cs
@@ -63,6 +63,16 @@ public sealed class GameSession(
             _projectiles.AddRange(projectiles);
     }
 
+    public void Reload()
+    {
+        Player.ReloadWeapon();
+    }
+
+    public void AddAmmo(int value)
+    {
+        Player.AddAmmo(value);
+    }
+
     public void RotatePlayerTowards(Vector2 target) =>
         Player.RotateTowards(target);
 

--- a/src/Swarm.Domain/Entities/Player.cs
+++ b/src/Swarm.Domain/Entities/Player.cs
@@ -11,19 +11,33 @@ public sealed class Player(
     EntityId id,
     Vector2 startPos,
     Radius radius,
-    Weapon weapon
+    PlayerWeapon weapon,
+    int initialAmmo = 0
 ) : ILivingEntity
 {
     public EntityId Id { get; } = id;
     public Vector2 Position { get; private set; } = startPos;
     private Vector2 _lastPosition = startPos;  
     public Radius Radius { get; } = radius;
-    public Weapon ActiveWeapon { get; private set; } = weapon;
+    public PlayerWeapon ActiveWeapon { get; private set; } = weapon;
     public Direction Direction { get; private set; } = Direction.From(1, 0);
     public Direction Rotation { get; private set; } = Direction.From(1, 0);
     public float Speed { get; private set; } = 0f;
     public HitPoints HP { get; private set; } = new(100);
+    public int Ammo { get; private set; } = initialAmmo;
     public bool IsDead => HP.IsZero;
+
+    public void ReloadWeapon()
+    {
+        ActiveWeapon.Reload(Ammo, out var ammoUsed);
+        Ammo -= ammoUsed;
+    }
+
+    public void AddAmmo(int amount)
+    {
+        if (amount > 0)
+            Ammo += amount;
+    }
 
     public void RotateTowards(Vector2 target)
     {

--- a/src/Swarm.Domain/Entities/Weapons/PlayerWeapon.cs
+++ b/src/Swarm.Domain/Entities/Weapons/PlayerWeapon.cs
@@ -1,0 +1,46 @@
+﻿using Swarm.Domain.Entities.Projectiles;
+using Swarm.Domain.Interfaces;
+using Swarm.Domain.Primitives;
+using Swarm.Domain.Time;
+
+namespace Swarm.Domain.Entities.Weapons;
+
+public class PlayerWeapon(
+    string name,
+    IFirePattern pattern,
+    Cooldown cooldown,
+    ProjectileOwnerTypes ownerType,
+    int maxAmmo
+) : Weapon(pattern, cooldown, ownerType)
+{
+    public string Name { get; } = name;
+    public int MaxAmmo { get; } = maxAmmo;
+    public int CurrentAmmo { get; private set; } = maxAmmo;
+
+    public override bool TryFire(Vector2 origin, Direction facing, out IEnumerable<Projectile> projectiles)
+    {
+        if (CurrentAmmo <= 0)
+        {
+            projectiles = [];
+            return false;
+        }
+
+        var fired = base.TryFire(origin, facing, out projectiles);
+        if (fired)
+            CurrentAmmo--;
+
+        return fired;
+    }
+    public void Reload(int availableAmmo, out int ammoUsed)
+    {
+        ammoUsed = 0;
+
+        if (CurrentAmmo >= MaxAmmo || availableAmmo <= 0)
+            return;
+
+        int needed = MaxAmmo - CurrentAmmo;
+        ammoUsed = Math.Min(needed, availableAmmo);
+
+        CurrentAmmo += ammoUsed;
+    }
+}

--- a/src/Swarm.Presentation/Input/InputManager.cs
+++ b/src/Swarm.Presentation/Input/InputManager.cs
@@ -20,12 +20,14 @@ public sealed class InputManager
         bool fire = (kb.IsKeyDown(Keys.Space) && !_prevKb.IsKeyDown(Keys.Space))
                  || (mouse.LeftButton == ButtonState.Pressed && _prevMouse.LeftButton == ButtonState.Released);
 
+        bool reload = kb.IsKeyDown(Keys.E) && ! _prevKb.IsKeyDown(Keys.E);
+
         bool pause = kb.IsKeyDown(Keys.P) && !_prevKb.IsKeyDown(Keys.P);
 
         bool save = kb.IsKeyDown(Keys.F5) && !_prevKb.IsKeyDown(Keys.F5);
         bool load = kb.IsKeyDown(Keys.F9) && !_prevKb.IsKeyDown(Keys.F9);
 
-        var state = new InputState(dx, dy, mouse.X, mouse.Y, fire, pause, save, load);
+        var state = new InputState(dx, dy, mouse.X, mouse.Y, fire, reload, pause, save, load);
 
         _prevKb = kb;
         _prevMouse = mouse;

--- a/src/Swarm.Presentation/Input/InputState.cs
+++ b/src/Swarm.Presentation/Input/InputState.cs
@@ -6,6 +6,7 @@ public readonly record struct InputState(
     float MouseX,
     float MouseY,
     bool Fire,
+    bool Reload,
     bool Pause,
     bool Save,
     bool Load

--- a/src/Swarm.Presentation/Renderers/HudRenderer.cs
+++ b/src/Swarm.Presentation/Renderers/HudRenderer.cs
@@ -19,13 +19,14 @@ public class HudRenderer(
 
     public void Draw(HudDTO hud)
     {
-        var scoreText = $"Score: {hud.Score}";
+        var scoreText = $"Enemies killed: {hud.Score}";
         var hpText = $"HP: {hud.HP}";
         var enemiesText = $"Enemies alive: {hud.NumberOfEnemiesAlive}";
+        var weaponString = hud.WeaponString;
 
         var timerText = $"Timer: {hud.Timer}";
         
-        var leftText = $"{hpText} {scoreText} {enemiesText} {timerText}";
+        var leftText = $"{hpText} {weaponString} {scoreText} {enemiesText} {timerText}";
         var leftPos = new Vector2(10, 10);
 
         var levelText = $"{hud.GameLevel}";

--- a/src/Swarm.Presentation/Swarm.cs
+++ b/src/Swarm.Presentation/Swarm.cs
@@ -49,14 +49,16 @@ public class Swarm : Game
             ),
             LevelConfig: new LevelConfig(
                 Weapon: new WeaponConfig(
+                    Name: "oitão",
                     Damage: 1,
-                    ProjectileSpeed: 420f,
+                    ProjectileSpeed: 840f,
                     ProjectileRadius: 4f,
                     RatePerSecond: 6f,
-                    ProjectileLifetimeSeconds: 2.0f
+                    ProjectileLifetimeSeconds: 1.2f,
+                    MaxAmmo: 6
                 ),
-                PlayerAreaConfig: new AreaConfig(X: 50, Y: 50, Radius: 20),
-                TargetAreaConfig: new AreaConfig(X: 900, Y: 500, Radius: 20),
+                PlayerAreaConfig: new AreaConfig(X: 50, Y: 50, Radius: 40),
+                TargetAreaConfig: new AreaConfig(X: 900, Y: 500, Radius: 40),
                 Walls:
                 [
                     new(X: 200, Y: 100, Radius: 30),
@@ -64,12 +66,12 @@ public class Swarm : Game
                 ],
                 Spawners:
                 [
-                    // new(
-                    //     X: 400,
-                    //     Y: 300, CooldownSeconds: 0.8f,
-                    //     BehaviourType: "",
-                    //     SpawnObjectType: "BasicEnemy"
-                    // ),
+                    new(
+                        X: 400,
+                        Y: 300, CooldownSeconds: 0.8f,
+                        BehaviourType: "",
+                        SpawnObjectType: "BasicEnemy"
+                    ),
 
                     new(
                         X: 600,
@@ -136,6 +138,8 @@ public class Swarm : Game
         _service.ApplyInput(state.DirX, state.DirY, (state.DirX == 0f && state.DirY == 0f) ? 0f : _moveSpeed);
 
         if (state.Fire) _service.Fire();
+
+        if (state.Reload) _service.Reload();
 
         _service.RotateTowards(state.MouseX, state.MouseY);
 


### PR DESCRIPTION
  d42370a (HEAD -> feature/Player-Weapon, origin/feature/Player-Weapon) Merge pull request #40 from wierdest/task/Presentation
|\  
| * 32b54af (origin/task/Presentation, task/Presentation) :trophy::video_game::gun: Presentation implementa um tipo básico de arma
| * 9dd7721 :computer: HudRenderer renderiza a string de info sobre a arma
| * bfd6db3 :joystick: Input para a tecla E como reload
|/  
*   4f66c68 Merge pull request #39 from wierdest/task/Application
|\  
| * a0c4de3 (origin/task/Application) :video_game::gun: GameSessionService monta PlayerWeapon e implementa reload
| * 042501f :earth_africa: DomainMapper mapeia string de info sobre arma
| * 848a8a6 :computer: HudDTO passa info sobre armas e reload
| * 5a1b7f4 :gun: Reload no contrato da service
| * e6e548b :gun: WeaponConfig atende a PlayerWeapon
|/  
*   9ebcc4b Merge pull request #38 from wierdest/task/Domain
|\  
| | *   b5ce2ea (origin/feature/Player-Rotation) Merge pull request #37 from wierdest/revert-36-task/Domain
| | |\  
| | | * 6c17d4f (origin/revert-36-task/Domain) Revert "Task/domain"
| | |/  
| | *   f103fb7 Merge pull request #36 from wierdest/task/Domain
| |/|   
| * | 9ada0e4 (origin/task/Domain) :gun::video_game::joystick Reload
| * | a03d28b :joystick::gun: Estendendo weapon para Player com controle de ammo e reload
|/ /  
